### PR TITLE
deps: upgrade sqlserver residual testcontainers packages

### DIFF
--- a/tests/integration/Syrx.SqlServer.Tests.Integration/Syrx.SqlServer.Tests.Integration.csproj
+++ b/tests/integration/Syrx.SqlServer.Tests.Integration/Syrx.SqlServer.Tests.Integration.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 <PackageReference Include="Syrx.Validation" Version="3.0.0" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/performance/Syrx.SqlServer.Tests.Performance/Syrx.SqlServer.Tests.Performance.csproj
+++ b/tests/performance/Syrx.SqlServer.Tests.Performance/Syrx.SqlServer.Tests.Performance.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
   </ItemGroup>


### PR DESCRIPTION
This pull request updates the `Testcontainers.MsSql` package version in the integration and performance test projects. This ensures that both test suites use the latest features and bug fixes from the `Testcontainers.MsSql` library.

Dependency updates:

* Upgraded `Testcontainers.MsSql` from version 4.11.0 to 4.12.0 in `Syrx.SqlServer.Tests.Integration.csproj` and `Syrx.SqlServer.Tests.Performance.csproj`. [[1]](diffhunk://#diff-480966cdf50b002be55d295acb8be4f88482fe7903254a38dac5a49cf12b5c53L19-R19) [[2]](diffhunk://#diff-8a555fb8eb1ff88b6b3c3e35aa310db663c73a096b10275730af3e38a4c73fd6L25-R25)